### PR TITLE
[SYCL][CUDA] bfloat16 class supports all sm_xx devices.

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.cpp
+++ b/clang/lib/Basic/Targets/NVPTX.cpp
@@ -181,7 +181,7 @@ void NVPTXTargetInfo::getTargetDefines(const LangOptions &Opts,
                                        MacroBuilder &Builder) const {
   Builder.defineMacro("__PTX__");
   Builder.defineMacro("__NVPTX__");
-  if (Opts.CUDAIsDevice || Opts.OpenMPIsDevice) {
+  if (Opts.CUDAIsDevice || Opts.OpenMPIsDevice || Opts.SYCLIsDevice) {
     // Set __CUDA_ARCH__ for the GPU specified.
     std::string CUDAArchCode = [this] {
       switch (GPU) {


### PR DESCRIPTION
This is an example of how the CUDA backend can support software implementations for sm_xx < sm_80, in addition to the sm_80 builtins where they exist.

Note that this does not add software implementations of the bfloat16 math functions which currently still require sm_80.

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>